### PR TITLE
Reset recoil pattern on toggle and weapon switch

### DIFF
--- a/message.lua
+++ b/message.lua
@@ -110,6 +110,7 @@ function OnEvent(event, arg)
             -- Toggle recoil ON/OFF
             isRecoilEnabled = not isRecoilEnabled
             OutputLogMessage("Recoil %s\n", isRecoilEnabled and "ON" or "OFF")
+            recoilIndex = 1 -- reset pattern when toggling
 
         elseif arg == 4 then
             -- Switch weapon profile
@@ -118,6 +119,7 @@ function OnEvent(event, arg)
             else
                 currentWeapon = "ash"
             end
+            recoilIndex = 1 -- reset pattern on weapon change
             OutputLogMessage("Switched to: %s\n", getWeapon().name)
 
         elseif arg == 1 and isRecoilEnabled then


### PR DESCRIPTION
## Summary
- restart the recoil sequence whenever recoil is toggled on/off
- reset the recoil index when switching weapons

## Testing
- `luac -p message.lua`


------
https://chatgpt.com/codex/tasks/task_e_6897ddaeefe8832b9199b0ef04ca94d4