### PR TITLE
Normalize recoil patterns for Ash and 552

### DIFF
--- a/message.lua
+++ b/message.lua
@@ -24,49 +24,51 @@ local weapons = {
         Y_FROM1       = 8,
         Y_FROM2       = 13,
         pattern = {
-            {x =  0, y = 31, delay = 7},
-            {x = -1, y = 29, delay = 7},
-            {x =  0, y = 26, delay = 6},
-            {x = -1, y = 27, delay = 5},
-            {x =  0, y = 25, delay = 5},
-            {x =  0, y = 23, delay = 4},
-            {x =  0, y = 21, delay = 4},
-            {x = -1, y = 21, delay = 3},
-            {x =  0, y = 18, delay = 3},
-            {x = -1, y = 16, delay = 3},
-            {x = -1, y = 13, delay = 3},
-            {x = -1, y = 11, delay = 3},
-            {x = -1, y =  9, delay = 3},
-            {x = -1, y =  7, delay = 3},
-            {x = -1, y =  6, delay = 3},
+            -- Normalized values to ensure the recoil compensation ramps down smoothly
+            { x =  0, y = 31, delay = 7 },
+            { x = -1, y = 29, delay = 7 },
+            { x =  0, y = 26, delay = 6 },
+            { x = -1, y = 24, delay = 5 },
+            { x =  0, y = 22, delay = 5 },
+            { x =  0, y = 20, delay = 4 },
+            { x =  0, y = 18, delay = 4 },
+            { x = -1, y = 16, delay = 3 },
+            { x =  0, y = 14, delay = 3 },
+            { x = -1, y = 12, delay = 3 },
+            { x = -1, y = 10, delay = 3 },
+            { x = -1, y =  8, delay = 3 },
+            { x = -1, y =  6, delay = 3 },
+            { x = -1, y =  4, delay = 3 },
+            { x = -1, y =  2, delay = 3 },
         }
     },
 
-["552"] = { -- Grim’s 552 Commando recoil compensation
-    name = "552 Commando (Grim)",
-    X_SHIFT_EARLY = 0,
-    X_SHIFT_MID   = 0,
-    X_SHIFT_LATE  = 0,
-    X_FROM1       = 1,
-    X_FROM2       = 6,
-    Y_SCALE_MID   = 1.0,
-    Y_SCALE_LATE  = 1.05,
-    Y_FROM1       = 4,
-    Y_FROM2       = 8,
-    pattern = {
-        { x = -1,  y = -20, delay = 7 },
-        { x = -1,  y = -19, delay = 6 },
-        { x = -1,  y = -18, delay = 6 },
-        { x = -1,  y = -17, delay = 5 },
-        { x = -1,  y = -16, delay = 5 },
-        { x = -1,  y = -15, delay = 4 },
-        { x = -1,  y = -14, delay = 4 },
-        { x = -1,  y = -13, delay = 3 },
-        { x = -1,  y = -12, delay = 3 },
-        { x = -1,  y = -11, delay = 3 },
-        { x = -1,  y = -10, delay = 3 },
+    ["552"] = { -- Grim’s 552 Commando recoil compensation
+        name = "552 Commando (Grim)",
+        X_SHIFT_EARLY = 0,
+        X_SHIFT_MID   = 0,
+        X_SHIFT_LATE  = 0,
+        X_FROM1       = 1,
+        X_FROM2       = 6,
+        Y_SCALE_MID   = 1.0,
+        Y_SCALE_LATE  = 1.05,
+        Y_FROM1       = 4,
+        Y_FROM2       = 8,
+        pattern = {
+            -- All Y values are positive so that the mouse is moved down to compensate for recoil
+            { x = -1, y = 20, delay = 7 },
+            { x = -1, y = 19, delay = 6 },
+            { x = -1, y = 18, delay = 6 },
+            { x = -1, y = 17, delay = 5 },
+            { x = -1, y = 16, delay = 5 },
+            { x = -1, y = 15, delay = 4 },
+            { x = -1, y = 14, delay = 4 },
+            { x = -1, y = 13, delay = 3 },
+            { x = -1, y = 12, delay = 3 },
+            { x = -1, y = 11, delay = 3 },
+            { x = -1, y = 10, delay = 3 },
+        }
     }
-}
 }
 
 -- === Helpers ===
@@ -118,6 +120,7 @@ function OnEvent(event, arg)
             else
                 currentWeapon = "ash"
             end
+            recoilIndex = 1
             OutputLogMessage("Switched to: %s\n", getWeapon().name)
 
         elseif arg == 1 and isRecoilEnabled then
@@ -138,7 +141,7 @@ function OnEvent(event, arg)
         end
     end
 
-    if event == "MOUSE_BUTTON_RELEASED" and arg == 1 then
+    if event == "MOUSE_BUTTON_RELEASED" and (arg == 1 or arg == 3) then
         recoilIndex = 1
     end
 end


### PR DESCRIPTION
## Summary
- smooth out Ash R4-C recoil table for consistent downward movement
- correct 552 Commando pattern so Y offsets are positive and indent the weapon definition
- reset recoil index when switching profiles or releasing the right mouse button

## Testing
- `luac -p message.lua`


------
https://chatgpt.com/codex/tasks/task_e_6897ddd00420832b9ff985cfe614273a